### PR TITLE
docs/missing documentation

### DIFF
--- a/contracts/QuantCalculator.sol
+++ b/contracts/QuantCalculator.sol
@@ -57,6 +57,7 @@ contract QuantCalculator is IQuantCalculator {
         optionsFactory = _optionsFactory;
     }
 
+    /// @inheritdoc IQuantCalculator
     function calculateClaimableCollateral(
         uint256 _collateralTokenId,
         uint256 _amount,
@@ -161,6 +162,7 @@ contract QuantCalculator is IQuantCalculator {
             .toScaledUint(payoutDecimals, true);
     }
 
+    /// @inheritdoc IQuantCalculator
     function getNeutralizationPayout(
         address _qTokenShort,
         address _qTokenLong,
@@ -191,6 +193,7 @@ contract QuantCalculator is IQuantCalculator {
         collateralOwed = collateralOwedFP.toScaledUint(payoutDecimals, true);
     }
 
+    /// @inheritdoc IQuantCalculator
     function getCollateralRequirement(
         address _qTokenToMint,
         address _qTokenForCollateral,
@@ -226,6 +229,7 @@ contract QuantCalculator is IQuantCalculator {
         );
     }
 
+    /// @inheritdoc IQuantCalculator
     function getExercisePayout(address _qToken, uint256 _amount)
         external
         view

--- a/contracts/QuantCalculator.sol
+++ b/contracts/QuantCalculator.sol
@@ -9,15 +9,24 @@ import "./libraries/FundsCalculator.sol";
 import "./libraries/OptionsUtils.sol";
 import "./libraries/QuantMath.sol";
 
+/// @title Calculates collateral requirements and payouts for Quant options.
+/// @author Rolla
+/// @dev Uses fixed point arithmetic from the QuantMath library.
 contract QuantCalculator is IQuantCalculator {
     using QuantMath for uint256;
     using QuantMath for int256;
     using QuantMath for QuantMath.FixedPointInt;
 
+    /// @inheritdoc IQuantCalculator
     uint8 public constant override OPTIONS_DECIMALS = 18;
+
+    /// @inheritdoc IQuantCalculator
     uint8 public immutable override strikeAssetDecimals;
+
+    /// @inheritdoc IQuantCalculator
     address public immutable override optionsFactory;
 
+    /// @notice Checks that the QToken was created through the configured OptionsFactory
     modifier validQToken(address _qToken) {
         require(
             IOptionsFactory(optionsFactory).isQToken(_qToken),
@@ -27,6 +36,8 @@ contract QuantCalculator is IQuantCalculator {
         _;
     }
 
+    /// @notice Checks that the QToken used as collateral for a spread is either the zero address
+    /// or a QToken created through the configured OptionsFactory
     modifier validQTokenAsCollateral(address _qTokenAsCollateral) {
         if (_qTokenAsCollateral != address(0)) {
             // it could be the zero address for the qTokenAsCollateral for non-spreads
@@ -39,6 +50,8 @@ contract QuantCalculator is IQuantCalculator {
         _;
     }
 
+    /// @param _strikeAssetDecimals the number of decimals used to denominate strike prices
+    /// @param _optionsFactory the address of the OptionsFactory contract
     constructor(uint8 _strikeAssetDecimals, address _optionsFactory) {
         strikeAssetDecimals = _strikeAssetDecimals;
         optionsFactory = _optionsFactory;

--- a/contracts/QuantCalculator.sol
+++ b/contracts/QuantCalculator.sol
@@ -9,7 +9,7 @@ import "./libraries/FundsCalculator.sol";
 import "./libraries/OptionsUtils.sol";
 import "./libraries/QuantMath.sol";
 
-/// @title Calculates collateral requirements and payouts for Quant options.
+/// @title For calculating collateral requirements and payouts for options and spreads
 /// @author Rolla
 /// @dev Uses fixed point arithmetic from the QuantMath library.
 contract QuantCalculator is IQuantCalculator {

--- a/contracts/QuantConfig.sol
+++ b/contracts/QuantConfig.sol
@@ -167,6 +167,7 @@ contract QuantConfig is
     }
 
     /// @notice Sets a new protocol role, while also assigning a role admin
+    /// @dev If the role already exists in the config, only the role admin will be changed
     function _setProtocolRole(string memory _protocolRole, address _roleAdmin)
         internal
     {

--- a/contracts/QuantConfig.sol
+++ b/contracts/QuantConfig.sol
@@ -6,7 +6,8 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "./libraries/ProtocolValue.sol";
 import "./interfaces/ITimelockedConfig.sol";
 
-/// @title A central config for the quant system. Also acts as a central access control manager.
+/// @title A central config for the Quant Protocol. Also acts as a central access control manager.
+/// @author Rolla
 /// @notice For storing constants, variables and allowing them to be changed by the admin (governance)
 /// @dev This should be used as a central access control manager which other contracts use to check permissions
 contract QuantConfig is

--- a/contracts/QuantConfig.sol
+++ b/contracts/QuantConfig.sol
@@ -15,24 +15,35 @@ contract QuantConfig is
     OwnableUpgradeable,
     ITimelockedConfig
 {
+    /// @inheritdoc ITimelockedConfig
     address payable public override timelockController;
 
+    /// @inheritdoc ITimelockedConfig
     mapping(bytes32 => address) public override protocolAddresses;
+    /// @inheritdoc ITimelockedConfig
     bytes32[] public override configuredProtocolAddresses;
 
+    /// @inheritdoc ITimelockedConfig
     mapping(bytes32 => uint256) public override protocolUints256;
+    /// @inheritdoc ITimelockedConfig
     bytes32[] public override configuredProtocolUints256;
 
+    /// @inheritdoc ITimelockedConfig
     mapping(bytes32 => bool) public override protocolBooleans;
+    /// @inheritdoc ITimelockedConfig
     bytes32[] public override configuredProtocolBooleans;
 
+    /// @inheritdoc ITimelockedConfig
     mapping(string => bytes32) public override quantRoles;
+    /// @inheritdoc ITimelockedConfig
     bytes32[] public override configuredQuantRoles;
 
+    /// @inheritdoc ITimelockedConfig
     mapping(bytes32 => mapping(ProtocolValue.Type => bool))
         public
         override isProtocolValueSet;
 
+    /// @inheritdoc ITimelockedConfig
     function setProtocolAddress(bytes32 _protocolAddress, address _newValue)
         external
         override
@@ -55,6 +66,7 @@ contract QuantConfig is
         emit SetProtocolAddress(_protocolAddress, previousValue, _newValue);
     }
 
+    /// @inheritdoc ITimelockedConfig
     function setProtocolUint256(bytes32 _protocolUint256, uint256 _newValue)
         external
         override
@@ -68,6 +80,7 @@ contract QuantConfig is
         emit SetProtocolUint256(_protocolUint256, previousValue, _newValue);
     }
 
+    /// @inheritdoc ITimelockedConfig
     function setProtocolBoolean(bytes32 _protocolBoolean, bool _newValue)
         external
         override
@@ -86,6 +99,7 @@ contract QuantConfig is
         emit SetProtocolBoolean(_protocolBoolean, previousValue, _newValue);
     }
 
+    /// @inheritdoc ITimelockedConfig
     function setProtocolRole(string calldata _protocolRole, address _roleAdmin)
         external
         override
@@ -94,6 +108,7 @@ contract QuantConfig is
         _setProtocolRole(_protocolRole, _roleAdmin);
     }
 
+    /// @inheritdoc ITimelockedConfig
     function setRoleAdmin(bytes32 role, bytes32 adminRole)
         external
         override
@@ -104,6 +119,7 @@ contract QuantConfig is
         emit SetRoleAdmin(role, adminRole);
     }
 
+    /// @inheritdoc ITimelockedConfig
     function protocolAddressesLength()
         external
         view
@@ -113,21 +129,22 @@ contract QuantConfig is
         return configuredProtocolAddresses.length;
     }
 
+    /// @inheritdoc ITimelockedConfig
     function protocolUints256Length() external view override returns (uint256) {
         return configuredProtocolUints256.length;
     }
 
+    /// @inheritdoc ITimelockedConfig
     function protocolBooleansLength() external view override returns (uint256) {
         return configuredProtocolBooleans.length;
     }
 
+    /// @inheritdoc ITimelockedConfig
     function quantRolesLength() external view override returns (uint256) {
         return configuredQuantRoles.length;
     }
 
-    /// @notice Initializes the system roles and assign them to the given TimelockController address
-    /// @param _timelockController Address of the TimelockController to receive the system roles
-    /// @dev The TimelockController should have a Quant multisig as its sole proposer
+    /// @inheritdoc ITimelockedConfig
     function initialize(address payable _timelockController)
         public
         override
@@ -149,6 +166,7 @@ contract QuantConfig is
         timelockController = _timelockController;
     }
 
+    /// @notice Sets a new protocol role, while also assigning a role admin
     function _setProtocolRole(string memory _protocolRole, address _roleAdmin)
         internal
     {

--- a/contracts/interfaces/IAssetsRegistry.sol
+++ b/contracts/interfaces/IAssetsRegistry.sol
@@ -35,18 +35,27 @@ interface IAssetsRegistry {
 
     /// @notice Returns the name, symbol and decimals of an asset that's already in the registry
     /// @dev Will return empty strings and zero for non-existent assets
-    function assetProperties(address)
+    /// @return name asset's name
+    /// @return symbol asset's symbol
+    /// @return decimals asset's decimals
+    function assetProperties(address asset)
         external
         view
         returns (
-            string memory,
-            string memory,
-            uint8
+            string memory name,
+            string memory symbol,
+            uint8 decimals
         );
 
     /// @notice Returns the address of the asset at the given index
-    function registeredAssets(uint256) external view returns (address);
+    /// @param index index of the asset in the registry
+    /// @return asset address of the asset at the given index
+    function registeredAssets(uint256 index)
+        external
+        view
+        returns (address asset);
 
     /// @notice Returns the number of assets in the registry
-    function getAssetsLength() external view returns (uint256);
+    /// @return length number of assets in the registry
+    function getAssetsLength() external view returns (uint256 length);
 }

--- a/contracts/interfaces/IAssetsRegistry.sol
+++ b/contracts/interfaces/IAssetsRegistry.sol
@@ -2,6 +2,11 @@
 pragma solidity ^0.8.0;
 
 interface IAssetsRegistry {
+    /// @notice emitted when a new asset is added to the registry
+    /// @param underlying address of the asset
+    /// @param name name of the asset
+    /// @param symbol symbol of the asset
+    /// @param decimals the amount of decimals the asset has
     event AssetAdded(
         address indexed underlying,
         string name,
@@ -9,15 +14,27 @@ interface IAssetsRegistry {
         uint8 decimals
     );
 
+    /// @notice Add a new asset to the registry
+    /// @dev It will revert when trying to add an asset with the same address twice
+    /// @dev Can only be called by addresses with the ASSETS_REGISTRY_MANAGER_ROLE role
+    /// @param _underlying address of the asset
+    /// @param _name name of the asset
+    /// @param _symbol symbol of the asset
+    /// @param _decimals the amount of decimals the asset has
     function addAsset(
-        address,
-        string calldata,
-        string calldata,
-        uint8
+        address _underlying,
+        string calldata _name,
+        string calldata _symbol,
+        uint8 _decimals
     ) external;
 
-    function addAssetWithOptionalERC20Methods(address) external;
+    /// @notice Add a new asset to the registry, calling the optional ERC20 methods
+    /// to get its name, symbol and decimals
+    /// @param _underlying address of the asset
+    function addAssetWithOptionalERC20Methods(address _underlying) external;
 
+    /// @notice Returns the name, symbol and decimals of an asset that's already in the registry
+    /// @dev Will return empty strings and zero for non-existent assets
     function assetProperties(address)
         external
         view
@@ -27,7 +44,9 @@ interface IAssetsRegistry {
             uint8
         );
 
+    /// @notice Returns the address of the asset at the given index
     function registeredAssets(uint256) external view returns (address);
 
+    /// @notice Returns the number of assets in the registry
     function getAssetsLength() external view returns (uint256);
 }

--- a/contracts/interfaces/IChainlinkFixedTimeOracleManager.sol
+++ b/contracts/interfaces/IChainlinkFixedTimeOracleManager.sol
@@ -4,8 +4,10 @@ pragma solidity ^0.8.0;
 import "./IChainlinkOracleManager.sol";
 
 interface IChainlinkFixedTimeOracleManager is IChainlinkOracleManager {
+    /// @notice emitted when a new time is added for fixed updates
     event FixedTimeUpdate(uint256 fixedTime, bool isValidTime);
 
+    /// @notice Validate or invalidated a given fixed time for updates
     function setFixedTimeUpdate(uint256 fixedTime, bool isValidTime) external;
 
     /// @notice fixed time => is allowed

--- a/contracts/interfaces/ICollateralToken.sol
+++ b/contracts/interfaces/ICollateralToken.sol
@@ -6,7 +6,7 @@ import "./IQuantConfig.sol";
 import "./IQToken.sol";
 
 /// @title Tokens representing a Quant user's short positions
-/// @author Quant Finance
+/// @author Rolla
 /// @notice Can be used by owners to claim their collateral
 interface ICollateralToken is IERC1155 {
     struct QTokensDetails {

--- a/contracts/interfaces/IController.sol
+++ b/contracts/interfaces/IController.sol
@@ -4,6 +4,13 @@ pragma solidity ^0.8.0;
 import "../libraries/Actions.sol";
 
 interface IController {
+    /// @notice emitted after a new position is created
+    /// @param mintedTo address that received both QTokens and CollateralTokens
+    /// @param minter address that provided collateral and created the position
+    /// @param qToken address of the QToken minted
+    /// @param optionsAmount amount of options minted
+    /// @param collateralAsset asset provided as collateral to create the position
+    /// @param collateralAmount amount of collateral provided
     event OptionsPositionMinted(
         address indexed mintedTo,
         address indexed minter,
@@ -13,6 +20,13 @@ interface IController {
         uint256 collateralAmount
     );
 
+    /// @notice emitted after a spread position is created
+    /// @param account address that created the spread position, receiving both QTokens and CollateralTokens
+    /// @param qTokenToMint QToken of the option the position is going long on
+    /// @param qTokenForCollateral QToken of the option the position is shorting
+    /// @param optionsAmount amount of qTokenToMint options minted
+    /// @param collateralAsset asset provided as collateral to create the position (if debit spread)
+    /// @param collateralAmount amount of collateral provided (if debit spread)
     event SpreadMinted(
         address indexed account,
         address indexed qTokenToMint,
@@ -22,6 +36,12 @@ interface IController {
         uint256 collateralAmount
     );
 
+    /// @notice emitted after a QToken is used to close a long position after expiry
+    /// @param account address that used the QToken to exercise the position
+    /// @param qToken address of the QToken representing the long position
+    /// @param amountExercised amount of options exercised
+    /// @param payout amount received from exercising the options
+    /// @param payoutAsset asset received after exercising the options
     event OptionsExercised(
         address indexed account,
         address indexed qToken,
@@ -30,6 +50,14 @@ interface IController {
         address payoutAsset
     );
 
+    /// @notice emitted after both QTokens and CollateralTokens are used to claim the initial collateral
+    /// that was used to create the position
+    /// @param account address that used the QTokens and CollateralTokens to claim the collateral
+    /// @param qToken address of the QToken representing the long position
+    /// @param amountNeutralized amount of options that were used to claim the collateral
+    /// @param collateralReclaimed amount of collateral returned
+    /// @param collateralAsset asset returned after claiming the collateral
+    /// @param longTokenReturned QToken returned if neutralizing a spread position
     event NeutralizePosition(
         address indexed account,
         address qToken,
@@ -39,6 +67,12 @@ interface IController {
         address longTokenReturned
     );
 
+    /// @notice emitted after a CollateralToken is used to close a short position after expiry
+    /// @param account address that used the CollateralToken to close the position
+    /// @param collateralTokenId ERC1155 id of the CollateralToken representing the short position
+    /// @param amountClaimed amount of CollateralToken used to close the position
+    /// @param collateralReturned amount returned of the asset used to mint the option
+    /// @param collateralAsset asset returned after claiming the collateral, i.e. the same used when minting the option
     event CollateralClaimed(
         address indexed account,
         uint256 indexed collateralTokenId,
@@ -47,8 +81,14 @@ interface IController {
         address collateralAsset
     );
 
-    function operate(ActionArgs[] memory) external returns (bool);
+    /// @notice The main entry point in the Quant Protocol. This function takes an array of actions
+    /// and executes them in order. Actions are passed encoded as ActionArgs structs, and then for each
+    /// different action, the relevant arguments are parsed and passed to the respective internal function
+    /// @dev For documentation of each individual action, see the corresponding internal function in Controller.sol
+    /// @param _actions array of ActionArgs structs, each representing an action to be executed
+    function operate(ActionArgs[] memory _actions) external returns (bool);
 
+    /// @notice Upgradable proxy initialization function called during deployment and upgrades
     function initialize(
         string memory,
         string memory,
@@ -56,9 +96,12 @@ interface IController {
         address
     ) external;
 
+    /// @notice Address of the OptionsFactory contract
     function optionsFactory() external view returns (address);
 
+    /// @notice Address of th OperateProxy contract deployed through the initialize function
     function operateProxy() external view returns (address);
 
+    /// @notice Address of the QuantCalculator being used
     function quantCalculator() external view returns (address);
 }

--- a/contracts/interfaces/IController.sol
+++ b/contracts/interfaces/IController.sol
@@ -86,6 +86,7 @@ interface IController {
     /// different action, the relevant arguments are parsed and passed to the respective internal function
     /// @dev For documentation of each individual action, see the corresponding internal function in Controller.sol
     /// @param _actions array of ActionArgs structs, each representing an action to be executed
+    /// @return boolean indicating whether the actions were successfully executed
     function operate(ActionArgs[] memory _actions) external returns (bool);
 
     /// @notice Upgradable proxy initialization function called during deployment and upgrades

--- a/contracts/interfaces/IOperateProxy.sol
+++ b/contracts/interfaces/IOperateProxy.sol
@@ -2,10 +2,14 @@
 pragma solidity ^0.8.0;
 
 interface IOperateProxy {
+    /// @notice emitted when a external contract call is executed
     event FunctionCallExecuted(
         address indexed originalSender,
         bytes returnData
     );
 
-    function callFunction(address, bytes memory) external;
+    /// @notice Makes a call to an external contract
+    /// @param callee address of the contract to call
+    /// @param data the calldata to send to the contract
+    function callFunction(address callee, bytes memory data) external;
 }

--- a/contracts/interfaces/IOracleRegistry.sol
+++ b/contracts/interfaces/IOracleRegistry.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import "./IQuantConfig.sol";
 
 /// @title For centrally managing a list of oracle providers
+/// @author Rolla
 /// @notice oracle provider registry for holding a list of oracle providers and their id
 interface IOracleRegistry {
     event AddedOracle(address oracle, uint256 oracleId);

--- a/contracts/interfaces/IPriceRegistry.sol
+++ b/contracts/interfaces/IPriceRegistry.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import "./IQuantConfig.sol";
 
 /// @title For centrally managing a log of settlement prices, for each option.
+/// @author Rolla
 interface IPriceRegistry {
     struct PriceWithDecimals {
         uint256 price;

--- a/contracts/interfaces/IProviderOracleManager.sol
+++ b/contracts/interfaces/IProviderOracleManager.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import "./IQuantConfig.sol";
 
 /// @title Oracle manager for holding asset addresses and their oracle addresses for a single provider
+/// @author Rolla
 /// @notice Once an oracle is added for an asset it can't be changed!
 interface IProviderOracleManager {
     event OracleAdded(address asset, address oracle);
@@ -46,6 +47,10 @@ interface IProviderOracleManager {
     /// @return the current price of the asset
     function getCurrentPrice(address _asset) external view returns (uint256);
 
+    /// @notice Checks if the option is valid for the oracle manager with the given parameters
+    /// @param _underlyingAsset the address of the underlying asset
+    /// @param _expiryTime the expiry timestamp of the option
+    /// @param _strikePrice the strike price of the option
     function isValidOption(
         address _underlyingAsset,
         uint256 _expiryTime,

--- a/contracts/interfaces/IQToken.sol
+++ b/contracts/interfaces/IQToken.sol
@@ -13,7 +13,7 @@ enum PriceStatus {
 }
 
 /// @title Token that represents a user's long position
-/// @author Quant Finance
+/// @author Rolla
 /// @notice Can be used by owners to exercise their options
 /// @dev Every option long position is an ERC20 token: https://eips.ethereum.org/EIPS/eip-20
 interface IQToken is IERC20, IERC20Permit {

--- a/contracts/interfaces/IQuantCalculator.sol
+++ b/contracts/interfaces/IQuantCalculator.sol
@@ -1,7 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
+/// @title For calculating collateral requirements and payouts for options and spreads
+/// @author Rolla
 interface IQuantCalculator {
+    /// @notice Calculates the amount of collateral that can be claimed back post-settlement
+    /// from a CollateralToken
+    /// @param _collateralTokenId the id of the collateral token that is being claimed
+    /// @param _amount the amount of the collateral token being claimed. passing 0 claims the
+    /// users whole collateral token balance (does a balance lookup)
+    /// @param _msgSender the address of the claiming account
+    /// @return returnableCollateral the amount of collateral that will be returned from the claim
+    /// @return collateralAsset the address of the asset that will be returned from the claim
+    /// @return amountToClaim the amount of collateral tokens claimed. can only different to _amount
+    /// when the _amount passed was 0 and the user had a collateral token balance > 0
     function calculateClaimableCollateral(
         uint256 _collateralTokenId,
         uint256 _amount,
@@ -15,12 +27,30 @@ interface IQuantCalculator {
             uint256 amountToClaim
         );
 
+    /// @notice Calculates the collateral required to mint an option or a spread
+    /// @param _qTokenToMint the desired qToken
+    /// @param _qTokenForCollateral for spreads, this is the address of the qtoken to be used as collateral.
+    /// for options, no collateral is provided so the zero address should be passed.
+    /// @param _amount the amount of options/spread to mint
+    /// @return collateral the address of the collateral token required
+    /// @return collateralAmount the amount of collateral that is required to mint the option/spread
     function getCollateralRequirement(
         address _qTokenToMint,
         address _qTokenForCollateral,
         uint256 _amount
     ) external view returns (address collateral, uint256 collateralAmount);
 
+    /// @notice Calculates exercisable amount of an option post-expiry
+    /// @param _qToken address of the qToken being exercised
+    /// @param _amount the amount of the qToken being exercised
+    /// @return isSettled true if there is a settlement price for this option
+    /// and it can be exercised. false if there is no settlement price for this
+    /// option meaning it can't be exercised. if this value is false, payoutToken
+    /// will return the zero address and payout amount will be 0.
+    /// @return payoutToken the token that will be received from exercise. this will
+    /// return the zero address if the option is unsettled (can't exercise unsettled option)
+    /// @return payoutAmount the amount of payoutToken that will be received from exercising.
+    /// zero if the option is unsettled (can't exercise unsettled option)
     function getExercisePayout(address _qToken, uint256 _amount)
         external
         view
@@ -30,6 +60,23 @@ interface IQuantCalculator {
             uint256 payoutAmount
         );
 
+    /// @notice Calculates the amount that will be received from neutralizing an option or spread.
+    /// Neutralizing is the opposite action to mint - you give collateral token and qToken and receive
+    /// back collateral required to mint. Thus, the calculation is the same as getting the collateral
+    /// requirement with the only difference being rounding.
+    /// For neutralizing a spread, not only will the collateral provided be returned (if any), but also
+    /// the qToken that was provided as collateral when minting the spread will also be returned.
+    /// @param _qTokenShort the desired qToken
+    /// @param _qTokenLong for spreads, this is the address of the qtoken to be used as collateral.
+    /// for options, no collateral is provided so the zero address should be passed.
+    /// @param _amountToNeutralize the amount of options/spread being neutralized
+    /// @return collateralType the token that will be returned from neutralizing. this is the same
+    /// as the token that was provided when minting since this method is returning that collateral
+    /// back.
+    /// @return collateralOwed the amount of collateral that will be returned from neutralizing.
+    /// given the same parameters used for minting this will return the same amount of collateral
+    /// in all cases except when there is rounding involved. in those cases, the difference will be
+    /// 1 unit of collateral less for the neutralize than the mint.
     function getNeutralizationPayout(
         address _qTokenShort,
         address _qTokenLong,

--- a/contracts/interfaces/IQuantCalculator.sol
+++ b/contracts/interfaces/IQuantCalculator.sol
@@ -3,31 +3,31 @@ pragma solidity ^0.8.0;
 
 interface IQuantCalculator {
     function calculateClaimableCollateral(
-        uint256,
-        uint256,
-        address
+        uint256 _collateralTokenId,
+        uint256 _amount,
+        address _msgSender
     )
         external
         view
         returns (
-            uint256,
-            address,
-            uint256
+            uint256 returnableCollateral,
+            address collateralAsset,
+            uint256 amountToClaim
         );
 
     function getCollateralRequirement(
-        address,
-        address,
-        uint256
-    ) external view returns (address, uint256);
+        address _qTokenToMint,
+        address _qTokenForCollateral,
+        uint256 _amount
+    ) external view returns (address collateral, uint256 collateralAmount);
 
-    function getExercisePayout(address, uint256)
+    function getExercisePayout(address _qToken, uint256 _amount)
         external
         view
         returns (
-            bool,
-            address,
-            uint256
+            bool isSettled,
+            address payoutToken,
+            uint256 payoutAmount
         );
 
     function getNeutralizationPayout(

--- a/contracts/interfaces/IQuantCalculator.sol
+++ b/contracts/interfaces/IQuantCalculator.sol
@@ -36,10 +36,13 @@ interface IQuantCalculator {
         uint256 _amountToNeutralize
     ) external view returns (address collateralType, uint256 collateralOwed);
 
+    /// @notice The amount of decimals for Quant options
     // solhint-disable-next-line func-name-mixedcase
     function OPTIONS_DECIMALS() external view returns (uint8);
 
+    /// @notice The amount of decimals for the strike asset used in the Quant Protocol
     function strikeAssetDecimals() external view returns (uint8);
 
+    /// @notice The address of the factory contract that creates Quant options
     function optionsFactory() external view returns (address);
 }

--- a/contracts/interfaces/ITimelockedConfig.sol
+++ b/contracts/interfaces/ITimelockedConfig.sol
@@ -4,77 +4,135 @@ pragma solidity ^0.8.0;
 import "../libraries/ProtocolValue.sol";
 
 interface ITimelockedConfig {
+    /// @notice emitted when a protocol address is set in the config
+    /// @param protocolAddress the encoded name of the protocol value
+    /// @param previousValue the previous value for the protocol address
+    /// @param newValue the new value for the protocol address
     event SetProtocolAddress(
         bytes32 protocolAddress,
         address previousValue,
         address newValue
     );
 
+    /// @notice emitted when a protocol uint256 is set in the config
+    /// @param protocolUint256 the encoded name of the protocol value
+    /// @param previousValue the previous value for the protocol uint256
+    /// @param newValue the new value for the protocol uint256
     event SetProtocolUint256(
-        bytes32 protocolAddress,
+        bytes32 protocolUint256,
         uint256 previousValue,
         uint256 newValue
     );
 
+    /// @notice emitted when a protocol boolean is set in the config
+    /// @param protocolBoolean the encoded name of the protocol value
+    /// @param previousValue the previous value for the protocol boolean
+    /// @param newValue the new value for the protocol boolean
     event SetProtocolBoolean(
         bytes32 protocolBoolean,
         bool previousValue,
         bool newValue
     );
 
+    /// @notice emitted when a protocol role is set in the config
+    /// @param protocolRole the name of the protocol role
+    /// @param role the encoded name of the protocol role
+    /// @param roleAdmin the address of the role admin
     event SetProtocolRole(string protocolRole, bytes32 role, address roleAdmin);
 
+    /// @notice emitted when a role admin is set
+    /// @param role the encoded name of the protocol role
+    /// @param adminRole the encoded name of the role to act as an admin
     event SetRoleAdmin(bytes32 role, bytes32 adminRole);
 
-    function setProtocolAddress(bytes32, address) external;
+    /// @notice Sets a address protocol value
+    /// @param _protocolAddress the encoded name of the protocol address
+    /// @param _newValue the new value for the protocol address
+    function setProtocolAddress(bytes32 _protocolAddress, address _newValue)
+        external;
 
-    function setProtocolUint256(bytes32, uint256) external;
+    /// @notice Sets a uint256 protocol value
+    /// @param _protocolUint256 the encoded name of the protocol uint256
+    /// @param _newValue the new value for the protocol uint256
+    function setProtocolUint256(bytes32 _protocolUint256, uint256 _newValue)
+        external;
 
-    function setProtocolBoolean(bytes32, bool) external;
+    /// @notice Sets a boolean protocol value
+    /// @param _protocolBoolean the encoded name of the protocol boolean
+    /// @param _newValue the new value for the protocol boolean
+    function setProtocolBoolean(bytes32 _protocolBoolean, bool _newValue)
+        external;
 
-    function setProtocolRole(string calldata, address) external;
+    /// @notice Sets a role protocol
+    /// @param _protocolRole the name of the protocol role
+    /// @param _roleAdmin the address of the role admin
+    function setProtocolRole(string calldata _protocolRole, address _roleAdmin)
+        external;
 
-    function setRoleAdmin(bytes32, bytes32) external;
+    /// @notice Sets a role admin
+    /// @param role the encoded name of the protocol role
+    /// @param adminRole the encoded name of the role to act as an admin
+    function setRoleAdmin(bytes32 role, bytes32 adminRole) external;
 
-    function initialize(address payable) external;
+    /// @notice Initializes the system roles and assign them to the given TimelockController address
+    /// @param _timelockController Address of the TimelockController to receive the system roles
+    /// @dev The TimelockController should have a Quant multisig as its sole proposer
+    function initialize(address payable _timelockController) external;
 
+    /// @notice Returns the address of the TimelockController
     function timelockController() external view returns (address payable);
 
+    /// @notice Given an encoded protocol value name, returns the address of the protocol value
     function protocolAddresses(bytes32) external view returns (address);
 
+    /// @notice Given an index, returns the encoded name for a protocol address value
     function configuredProtocolAddresses(uint256)
         external
         view
         returns (bytes32);
 
+    /// @notice Given an encoded protocol value name, returns the uint256 value of the protocol value
     function protocolUints256(bytes32) external view returns (uint256);
 
+    /// @notice Given an index, returns the encoded name for a protocol uint256 value
     function configuredProtocolUints256(uint256)
         external
         view
         returns (bytes32);
 
+    /// @notice Given an encoded protocol value name, returns the boolean value of the protocol value
     function protocolBooleans(bytes32) external view returns (bool);
 
+    /// @notice Given an index, returns the encoded name for a protocol boolean value
     function configuredProtocolBooleans(uint256)
         external
         view
         returns (bytes32);
 
+    /// @notice Given a protocol role name, returns the encoded name of the role
     function quantRoles(string calldata) external view returns (bytes32);
 
-    function isProtocolValueSet(bytes32, ProtocolValue.Type)
-        external
-        view
-        returns (bool);
+    /// @notice Checks if a given protocol value is already set in the config
+    /// @param protocolValueName the encoded name of the protocol value
+    /// @param protocolValueType the type of the protocol value
+    /// @return whether the protocol value is already set in the config
+    function isProtocolValueSet(
+        bytes32 protocolValueName,
+        ProtocolValue.Type protocolValueType
+    ) external view returns (bool);
 
+    /// @notice Array of roles configured in the Quant Protocol system through the QuantConfig
     function configuredQuantRoles(uint256) external view returns (bytes32);
 
+    /// @notice The length of the configuredProtocolAddresses array
     function protocolAddressesLength() external view returns (uint256);
 
+    /// @notice The length of the configuredProtocolUints256 array
     function protocolUints256Length() external view returns (uint256);
 
+    /// @notice The length of the configuredProtocolBooleans array
     function protocolBooleansLength() external view returns (uint256);
 
+    /// @notice The length of the configuredQuantRoles array
     function quantRolesLength() external view returns (uint256);
 }

--- a/contracts/libraries/Actions.sol
+++ b/contracts/libraries/Actions.sol
@@ -22,6 +22,8 @@ struct ActionArgs {
     bytes data; //extra data for function calls
 }
 
+/// @title Library to parse arguments for actions to be executed by the Controller
+/// @author Rolla
 library Actions {
     function parseMintOptionArgs(ActionArgs memory _args)
         internal

--- a/contracts/libraries/FundsCalculator.sol
+++ b/contracts/libraries/FundsCalculator.sol
@@ -5,6 +5,8 @@ import "./QuantMath.sol";
 import "../options/QToken.sol";
 import "../interfaces/IPriceRegistry.sol";
 
+/// @title For calculating collateral requirements and payouts for options and spreads
+/// @author Rolla
 library FundsCalculator {
     using QuantMath for uint256;
     using QuantMath for int256;
@@ -16,6 +18,14 @@ library FundsCalculator {
         QuantMath.FixedPointInt amount;
     }
 
+    /// @notice Calculates payout of an option post-expiry from a qToken address
+    /// @param _qToken the address of the qToken (option) which is being exercised
+    /// @param _amount the amount of the qToken which is being exercised
+    /// @param _optionsDecimals option decimals constant. qTokens have 18 decimals
+    /// @param _strikeAssetDecimals the amount of decimals the strike asset has
+    /// @param _expiryPrice the expiry price of the option with the amount of decimals
+    /// @return payoutToken the address of the payout token
+    /// @return payoutAmount the amount to be payed out as a fixed point type
     function getPayout(
         address _qToken,
         uint256 _amount,
@@ -45,6 +55,16 @@ library FundsCalculator {
         );
     }
 
+    /// @notice Calculates the collateral required to mint an option or a spread
+    /// @param _qTokenToMint the desired qToken
+    /// @param _qTokenForCollateral for spreads, this is the address of the qtoken to be used as collateral.
+    /// for options, no collateral is provided so the zero address should be passed.
+    /// @param _optionsAmount the amount of options/spread to mint
+    /// @param _optionsDecimals option decimals constant. qTokens have 18 decimals
+    /// @param _underlyingDecimals the amount of decimals the underlying asset has
+    /// @param _strikeAssetDecimals the amount of decimals the strike asset has
+    /// @return collateral the address of the collateral token required
+    /// @return collateralAmount the collateral amount required as a fixed point type
     function getCollateralRequirement(
         address _qTokenToMint,
         address _qTokenForCollateral,
@@ -114,6 +134,14 @@ library FundsCalculator {
             : qTokenToMint.strikeAsset();
     }
 
+    /// @notice Calculates payout of an option post-expiry from qToken attributes
+    /// @param _isCall true if the option is a call, false for a put
+    /// @param _strikePrice the strike price of the option
+    /// @param _amount the amount of options being exercised
+    /// @param _optionsDecimals option decimals constant. qTokens have 18 decimals
+    /// @param _strikeAssetDecimals the amount of decimals the strike asset has
+    /// @param _expiryPrice the expiry price of the option with the amount of decimals
+    /// @return payoutAmount the amount to be payed out as a fixed point type
     function getPayoutAmount(
         bool _isCall,
         uint256 _strikePrice,
@@ -136,6 +164,9 @@ library FundsCalculator {
         }
     }
 
+    /// @notice Calculates payout of a call given option payout inputs of strike, expiry and amount
+    /// @param payoutInput strike, expiry and amount as fixed points
+    /// @return payoutAmount the amount to be payed out as a fixed point type
     function getPayoutForCall(
         FundsCalculator.OptionPayoutInput memory payoutInput
     ) internal pure returns (QuantMath.FixedPointInt memory payoutAmount) {
@@ -150,6 +181,9 @@ library FundsCalculator {
             : int256(0).fromUnscaledInt();
     }
 
+    /// @notice Calculates payout of a put given option payout inputs of strike, expiry and amount
+    /// @param payoutInput strike, expiry and amount as fixed points
+    /// @return payoutAmount the amount to be payed out as a fixed point type
     function getPayoutForPut(
         FundsCalculator.OptionPayoutInput memory payoutInput
     ) internal pure returns (QuantMath.FixedPointInt memory payoutAmount) {
@@ -162,6 +196,18 @@ library FundsCalculator {
             : int256(0).fromUnscaledInt();
     }
 
+    /// @notice Calculates the collateral required to mint an option or spread
+    /// @param _qTokenToMintStrikePrice the strike price of the qToken being minted 
+    /// @param _qTokenForCollateralStrikePrice the strike price of the qToken being used as
+    /// collateral in the case of a spread
+    /// @param _optionsAmount the amount of options/spread being minted
+    /// @param _qTokenToMintIsCall whether or not the token to mint is a call. if a spread,
+    /// the qToken as collateral is implicitly also a call. and for minting a put, the 
+    /// qToken as collateral is implicitly also a put
+    /// @param _optionsDecimals option decimals constant. qTokens have 18 decimals
+    /// @param _underlyingDecimals the amount of decimals the underlying asset has
+    /// @param _strikeAssetDecimals the amount of decimals the strike asset has
+    /// @return collateralAmount the collateral amount required as a fixed point type    
     function getOptionCollateralRequirement(
         uint256 _qTokenToMintStrikePrice,
         uint256 _qTokenForCollateralStrikePrice,
@@ -192,6 +238,12 @@ library FundsCalculator {
         );
     }
 
+    /// @notice Calculates the collateral required to mint a single PUT option or PUT spread
+    /// @param _qTokenToMintStrikePrice the strike price of the PUT qToken being minted 
+    /// @param _qTokenForCollateralStrikePrice the strike price of the PUT qToken being used as
+    /// collateral in the case of a spread
+    /// @param _strikeAssetDecimals the amount of decimals the strike asset has
+    /// @return collateralPerOption the collateral amount required per option as a fixed point type
     function getPutCollateralRequirement(
         uint256 _qTokenToMintStrikePrice,
         uint256 _qTokenForCollateralStrikePrice,
@@ -221,6 +273,13 @@ library FundsCalculator {
         }
     }
 
+    /// @notice Calculates the collateral required to mint a single CALL option or CALL spread
+    /// @param _qTokenToMintStrikePrice the strike price of the CALL qToken being minted 
+    /// @param _qTokenForCollateralStrikePrice the strike price of the CALL qToken being
+    /// used as collateral in the case of a spread
+    /// @param _underlyingDecimals the amount of decimals the underlying asset has
+    /// @param _strikeAssetDecimals the amount of decimals the strike asset has
+    /// @return collateralPerOption the collateral amount required per option as a fixed point type
     function getCallCollateralRequirement(
         uint256 _qTokenToMintStrikePrice,
         uint256 _qTokenForCollateralStrikePrice,

--- a/contracts/libraries/FundsCalculator.sol
+++ b/contracts/libraries/FundsCalculator.sol
@@ -6,6 +6,7 @@ import "../options/QToken.sol";
 import "../interfaces/IPriceRegistry.sol";
 
 /// @title For calculating collateral requirements and payouts for options and spreads
+/// in a fixed point format
 /// @author Rolla
 library FundsCalculator {
     using QuantMath for uint256;

--- a/contracts/libraries/OptionsUtils.sol
+++ b/contracts/libraries/OptionsUtils.sol
@@ -12,7 +12,7 @@ import "../interfaces/IQToken.sol";
 import "../interfaces/IAssetsRegistry.sol";
 
 /// @title Options utilities for Quant's QToken and CollateralToken
-/// @author Quant Finance
+/// @author Rolla
 /// @dev This library must be deployed and linked while deploying contracts that use it
 library OptionsUtils {
     /// @notice constant salt because options will only be deployed with the same parameters once

--- a/contracts/libraries/OptionsUtils.sol
+++ b/contracts/libraries/OptionsUtils.sol
@@ -88,6 +88,12 @@ library OptionsUtils {
             _collateralToken.getCollateralTokenId(qToken, _qTokenAsCollateral);
     }
 
+    /// @notice Checks if the given option parameters are valid for creation in the Quant Protocol
+    /// @param _underlyingAsset asset that the option is for
+    /// @param _oracle price oracle for the option underlying
+    /// @param _expiryTime expiration timestamp as a unix timestamp
+    /// @param _quantConfig address of the QuantConfig contract
+    /// @param _strikePrice strike price with as many decimals in the strike asset
     function validateOptionParameters(
         address _underlyingAsset,
         address _oracle,
@@ -139,6 +145,10 @@ library OptionsUtils {
         );
     }
 
+    /// @notice Checks if a given asset is in the AssetsRegistry configured in the QuantConfig
+    /// @param _asset address of the asset to check
+    /// @param _quantConfig address of the QuantConfig contract
+    /// @return whether the asset is in the configured registry
     function isInAssetsRegistry(address _asset, address _quantConfig)
         internal
         view
@@ -154,6 +164,11 @@ library OptionsUtils {
         return bytes(symbol).length != 0;
     }
 
+    /// @notice Gets the amount of decimals for an option exercise payout
+    /// @param _strikeAssetDecimals decimals of the strike asset
+    /// @param _qToken address of the option's QToken contract
+    /// @param _quantConfig address of the QuantConfig contract
+    /// @return payoutDecimals amount of decimals for the option exercise payout
     function getPayoutDecimals(
         uint8 _strikeAssetDecimals,
         IQToken _qToken,
@@ -174,6 +189,9 @@ library OptionsUtils {
         }
     }
 
+    /// @notice Gets the option details for a given QToken
+    /// @param _qToken QToken to get the info for
+    /// @return qTokenInfo struct containing all the QToken details
     function getQTokenInfo(address _qToken)
         internal
         view

--- a/contracts/libraries/ProtocolValue.sol
+++ b/contracts/libraries/ProtocolValue.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.12;
 
+/// @title Library for QuantConfig's protocol values
+/// @author Rolla
 library ProtocolValue {
     enum Type {
         Address,
@@ -9,6 +11,9 @@ library ProtocolValue {
         Role
     }
 
+    /// @notice Gets the bytes32 encoded representation of a protocol value name
+    /// @param _protocolValue the name of the protocol value
+    /// @return the encoded bytes32 representation of the protocol value name
     function encode(string memory _protocolValue)
         internal
         pure

--- a/contracts/libraries/QuantMath.sol
+++ b/contracts/libraries/QuantMath.sol
@@ -5,6 +5,7 @@ import "./SignedConverter.sol";
 
 /**
  * @title QuantMath
+ * @author Rolla
  * @notice FixedPoint library
  */
 library QuantMath {

--- a/contracts/libraries/SignedConverter.sol
+++ b/contracts/libraries/SignedConverter.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.12;
 
 /**
  * @title SignedConverter
+ * @author Rolla
  * @notice A library to convert an unsigned integer to signed integer or signed integer to unsigned integer.
  */
 library SignedConverter {

--- a/contracts/options/AssetsRegistry.sol
+++ b/contracts/options/AssetsRegistry.sol
@@ -5,6 +5,8 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "../interfaces/IQuantConfig.sol";
 import "../interfaces/IAssetsRegistry.sol";
 
+/// @title For managing assets supported as underlying for options in the Quant Protocol
+/// @author Rolla
 contract AssetsRegistry is IAssetsRegistry {
     struct AssetProperties {
         string name;
@@ -39,6 +41,7 @@ contract AssetsRegistry is IAssetsRegistry {
         _;
     }
 
+    /// @param quantConfig_ address of the Quant central configuration contract
     constructor(address quantConfig_) {
         require(
             quantConfig_ != address(0),

--- a/contracts/options/AssetsRegistry.sol
+++ b/contracts/options/AssetsRegistry.sol
@@ -14,10 +14,14 @@ contract AssetsRegistry is IAssetsRegistry {
 
     IQuantConfig private _quantConfig;
 
+    /// @inheritdoc IAssetsRegistry
     mapping(address => AssetProperties) public override assetProperties;
 
+    /// @inheritdoc IAssetsRegistry
     address[] public override registeredAssets;
 
+    /// @dev Checks that the `msg.sender` has permission to add assets to the registry.
+    /// @dev Also checks that the asset had not been added before.
     modifier validAsset(address _underlying) {
         require(
             _quantConfig.hasRole(
@@ -44,6 +48,7 @@ contract AssetsRegistry is IAssetsRegistry {
         _quantConfig = IQuantConfig(quantConfig_);
     }
 
+    /// @inheritdoc IAssetsRegistry
     function addAsset(
         address _underlying,
         string calldata _name,
@@ -61,6 +66,7 @@ contract AssetsRegistry is IAssetsRegistry {
         emit AssetAdded(_underlying, _name, _symbol, _decimals);
     }
 
+    /// @inheritdoc IAssetsRegistry
     function addAssetWithOptionalERC20Methods(address _underlying)
         external
         override
@@ -85,6 +91,7 @@ contract AssetsRegistry is IAssetsRegistry {
         emit AssetAdded(_underlying, name, symbol, decimals);
     }
 
+    /// @inheritdoc IAssetsRegistry
     function getAssetsLength() external view override returns (uint256) {
         return registeredAssets.length;
     }

--- a/contracts/options/CollateralToken.sol
+++ b/contracts/options/CollateralToken.sol
@@ -40,12 +40,15 @@ contract CollateralToken is ERC1155, ICollateralToken, EIP712 {
     /// @notice Initializes a new ERC1155 multi-token contract for representing
     /// users' short positions
     /// @param _quantConfig the address of the Quant system configuration contract
+    /// @param _name name for the domain typehash in EIP712 meta transactions
+    /// @param _version version for the domain typehash in EIP712 meta transactions
+    /// @param uri_ URI for ERC1155 tokens metadata
     constructor(
         address _quantConfig,
         string memory _name,
         string memory _version,
-        string memory _uri
-    ) ERC1155(_uri) EIP712(_name, _version) {
+        string memory uri_
+    ) ERC1155(uri_) EIP712(_name, _version) {
         require(
             _quantConfig != address(0),
             "CollateralToken: invalid QuantConfig address"
@@ -220,6 +223,7 @@ contract CollateralToken is ERC1155, ICollateralToken, EIP712 {
         emit ApprovalForAll(owner, operator, approved);
     }
 
+    /// @inheritdoc ICollateralToken
     function getCollateralTokensLength()
         external
         view
@@ -229,6 +233,7 @@ contract CollateralToken is ERC1155, ICollateralToken, EIP712 {
         return collateralTokenIds.length;
     }
 
+    /// @inheritdoc ICollateralToken
     function getCollateralTokenInfo(uint256 id)
         external
         view

--- a/contracts/options/CollateralToken.sol
+++ b/contracts/options/CollateralToken.sol
@@ -43,11 +43,9 @@ contract CollateralToken is ERC1155, ICollateralToken, EIP712 {
     constructor(
         address _quantConfig,
         string memory _name,
-        string memory _version
-    )
-        ERC1155("https://tokens.rolla.finance/{id}.json")
-        EIP712(_name, _version)
-    {
+        string memory _version,
+        string memory _uri
+    ) ERC1155(_uri) EIP712(_name, _version) {
         require(
             _quantConfig != address(0),
             "CollateralToken: invalid QuantConfig address"

--- a/contracts/options/CollateralToken.sol
+++ b/contracts/options/CollateralToken.sol
@@ -6,7 +6,7 @@ import "../external/openzeppelin/ERC1155.sol";
 import "../interfaces/ICollateralToken.sol";
 
 /// @title Tokens representing a Quant user's short positions
-/// @author Quant Finance
+/// @author Rolla
 /// @notice Can be used by owners to claim their collateral
 /// @dev This is a multi-token contract that implements the ERC1155 token standard:
 /// https://eips.ethereum.org/EIPS/eip-1155

--- a/contracts/options/OptionsFactory.sol
+++ b/contracts/options/OptionsFactory.sol
@@ -10,7 +10,7 @@ import "../interfaces/IAssetsRegistry.sol";
 import "../interfaces/ICollateralToken.sol";
 
 /// @title Factory contract for Quant options
-/// @author Quant Finance
+/// @author Rolla
 /// @notice Creates tokens for long (QToken) and short (CollateralToken) positions
 /// @dev This contract follows the factory design pattern
 contract OptionsFactory is IOptionsFactory {

--- a/contracts/options/QToken.sol
+++ b/contracts/options/QToken.sol
@@ -12,7 +12,7 @@ import "../libraries/QuantMath.sol";
 import "./QTokenStringUtils.sol";
 
 /// @title Token that represents a user's long position
-/// @author Quant Finance
+/// @author Rolla
 /// @notice Can be used by owners to exercise their options
 /// @dev Every option long position is an ERC20 token: https://eips.ethereum.org/EIPS/eip-20
 contract QToken is ERC20Permit, QTokenStringUtils, IQToken {

--- a/contracts/pricing/OracleRegistry.sol
+++ b/contracts/pricing/OracleRegistry.sol
@@ -5,6 +5,7 @@ import "../interfaces/IQuantConfig.sol";
 import "../interfaces/IOracleRegistry.sol";
 
 /// @title For centrally managing a list of oracle providers
+/// @author Rolla
 /// @notice oracle provider registry for holding a list of oracle providers and their id
 contract OracleRegistry is IOracleRegistry {
     struct OracleInfo {

--- a/contracts/pricing/PriceRegistry.sol
+++ b/contracts/pricing/PriceRegistry.sol
@@ -6,6 +6,7 @@ import "../interfaces/IPriceRegistry.sol";
 import "../libraries/QuantMath.sol";
 
 /// @title For centrally managing a log of settlement prices, for each option.
+/// @author Rolla
 contract PriceRegistry is IPriceRegistry {
     using QuantMath for uint256;
     using QuantMath for QuantMath.FixedPointInt;

--- a/contracts/pricing/oracle/ChainlinkFixedTimeOracleManager.sol
+++ b/contracts/pricing/oracle/ChainlinkFixedTimeOracleManager.sol
@@ -5,6 +5,9 @@ import "./ChainlinkOracleManager.sol";
 import "../../interfaces/external/chainlink/IEACAggregatorProxy.sol";
 import "../../interfaces/IChainlinkFixedTimeOracleManager.sol";
 
+/// @title For managing Chainlink oracles with updates at fixed times.
+/// @author Rolla
+/// @notice Update times are counted as seconds since the start of the day.
 contract ChainlinkFixedTimeOracleManager is
     ChainlinkOracleManager,
     IChainlinkFixedTimeOracleManager
@@ -28,6 +31,7 @@ contract ChainlinkFixedTimeOracleManager is
 
     }
 
+    /// @inheritdoc IChainlinkFixedTimeOracleManager
     function setFixedTimeUpdate(uint256 fixedTime, bool isValidTime)
         external
         override
@@ -45,6 +49,7 @@ contract ChainlinkFixedTimeOracleManager is
         emit FixedTimeUpdate(fixedTime, isValidTime);
     }
 
+    /// @inheritdoc IProviderOracleManager
     function isValidOption(
         address,
         uint256 _expiryTime,
@@ -59,6 +64,11 @@ contract ChainlinkFixedTimeOracleManager is
         return chainlinkFixedTimeUpdates[timeInSeconds];
     }
 
+    /// @notice Gets the price and roundId for a given expiry time.
+    /// @param aggregator address of the Chainlink aggregator proxy contract
+    /// @param _expiryTimestamp option expiration timestamp in seconds since the Unix epoch
+    /// @param _roundIdAfterExpiry id of the round right after the expiry
+    /// @param _expiryRoundId id of the round right before or at the expiry
     function _getExpiryPrice(
         IEACAggregatorProxy aggregator,
         uint256 _expiryTimestamp,

--- a/contracts/pricing/oracle/ChainlinkOracleManager.sol
+++ b/contracts/pricing/oracle/ChainlinkOracleManager.sol
@@ -9,6 +9,7 @@ import "../../libraries/QuantMath.sol";
 import "../../interfaces/IChainlinkOracleManager.sol";
 
 /// @title For managing chainlink oracles for assets and submitting chainlink prices to the registry
+/// @author Rolla
 /// @notice Once an oracle is added for an asset it can't be changed!
 contract ChainlinkOracleManager is
     ProviderOracleManager,
@@ -128,6 +129,7 @@ contract ChainlinkOracleManager is
                 .toScaledUint(strikeAssetDecimals, true);
     }
 
+    /// @inheritdoc IProviderOracleManager
     function isValidOption(
         address,
         uint256,

--- a/contracts/pricing/oracle/ProviderOracleManager.sol
+++ b/contracts/pricing/oracle/ProviderOracleManager.sol
@@ -5,6 +5,7 @@ import "../../interfaces/IQuantConfig.sol";
 import "../../interfaces/IProviderOracleManager.sol";
 
 /// @title Oracle manager for holding asset addresses and their oracle addresses for a single provider
+/// @author Rolla
 /// @notice Once an oracle is added for an asset it can't be changed!
 abstract contract ProviderOracleManager is IProviderOracleManager {
     /// @inheritdoc IProviderOracleManager

--- a/contracts/test/MockAggregatorProxy.sol
+++ b/contracts/test/MockAggregatorProxy.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.12;
 import "../interfaces/external/chainlink/IEACAggregatorProxy.sol";
 
 /// @title Mock chainlink proxy
+/// @author Rolla
 contract MockAggregatorProxy is IEACAggregatorProxy {
     struct LatestRoundData {
         uint80 roundId;

--- a/contracts/test/QuantConfigV2.sol
+++ b/contracts/test/QuantConfigV2.sol
@@ -7,6 +7,7 @@ import "../libraries/ProtocolValue.sol";
 import "../interfaces/ITimelockedConfig.sol";
 
 /// @title A central config for the quant system. Also acts as a central access control manager.
+/// @author Rolla
 /// @notice For storing constants, variables and allowing them to be changed by the admin (governance)
 /// @dev This should be used as a central access control manager which other contracts use to check permissions
 contract QuantConfigV2 is

--- a/contracts/timelock/ConfigTimelockController.sol
+++ b/contracts/timelock/ConfigTimelockController.sol
@@ -5,10 +5,16 @@ import "./TimelockController.sol";
 import "../interfaces/IQuantConfig.sol";
 import "../libraries/ProtocolValue.sol";
 
+/// @title Timelock controller contract for setting values in the QuantConfig and scheduling calls
+/// to external contracts.
+/// @author Rolla
+/// @dev Built on top of OpenZeppelin's TimelockController.
 contract ConfigTimelockController is TimelockController {
     mapping(bytes32 => uint256) public delays;
 
     mapping(bytes32 => uint256) private _timestamps;
+
+    /// @notice The minimum delay for scheduled executions
     uint256 public minDelay;
 
     constructor(
@@ -22,6 +28,9 @@ contract ConfigTimelockController is TimelockController {
         minDelay = _minDelay;
     }
 
+    /// @notice Sets the delay for a specific protocol value
+    /// @param _protocolValue the bytes32 encoded representation of the protocol value
+    /// @param _newDelay the delay in seconds
     function setDelay(bytes32 _protocolValue, uint256 _newDelay)
         external
         onlyRole(EXECUTOR_ROLE)
@@ -30,6 +39,7 @@ contract ConfigTimelockController is TimelockController {
         delays[_protocolValue] = _newDelay >= minDelay ? _newDelay : minDelay;
     }
 
+    /// @inheritdoc TimelockController
     function schedule(
         address target,
         uint256 value,
@@ -47,6 +57,11 @@ contract ConfigTimelockController is TimelockController {
         super.schedule(target, value, data, predecessor, salt, delay, false);
     }
 
+    /// @notice Schedule a call to set a protocol address in the QuantConfig contract
+    /// @param protocolAddress the encoded name of the protocol address variable to set in the config
+    /// @param newAddress the new address value to set
+    /// @param quantConfig the address of the QuantConfig contract
+    /// @param eta timestamp from which the scheduled call can be executed
     function scheduleSetProtocolAddress(
         bytes32 protocolAddress,
         address newAddress,
@@ -81,6 +96,11 @@ contract ConfigTimelockController is TimelockController {
         );
     }
 
+    /// @notice Schedule a call to set a protocol uint256 in the QuantConfig contract
+    /// @param protocolUint256 the encoded name of the protocol uint256 variable to set in the config
+    /// @param newUint256 the new uint256 value to set
+    /// @param quantConfig the address of the QuantConfig contract
+    /// @param eta timestamp from which the scheduled call can be executed
     function scheduleSetProtocolUint256(
         bytes32 protocolUint256,
         uint256 newUint256,
@@ -115,6 +135,11 @@ contract ConfigTimelockController is TimelockController {
         );
     }
 
+    /// @notice Schedule a call to set a protocol boolean in the QuantConfig contract
+    /// @param protocolBoolean the encoded name of the protocol boolean variable to set in the config
+    /// @param newBoolean the new boolean value to set
+    /// @param quantConfig the address of the QuantConfig contract
+    /// @param eta timestamp from which the scheduled call can be executed
     function scheduleSetProtocolBoolean(
         bytes32 protocolBoolean,
         bool newBoolean,
@@ -148,6 +173,11 @@ contract ConfigTimelockController is TimelockController {
         );
     }
 
+    /// @notice Schedule a call to set a protocol role in the QuantConfig contract
+    /// @param protocolRole the name of the protocol role variable to set in the config
+    /// @param roleAdmin address to be the role admin
+    /// @param quantConfig the address of the QuantConfig contract
+    /// @param eta timestamp from which the scheduled call can be executed
     function scheduleSetProtocolRole(
         string calldata protocolRole,
         address roleAdmin,
@@ -182,6 +212,14 @@ contract ConfigTimelockController is TimelockController {
         );
     }
 
+    /// @notice Schedule multiple contract calls
+    /// @dev Cannot schedule calls to set protocol values in the QuantConfig
+    /// @param targets array of contracts to receive the scheduled calls
+    /// @param values array of values to be sent to the contracts
+    /// @param datas array of data to be sent to the contracts
+    /// @param predecessor extra 32 bytes to be used when hashing the operation batch
+    /// @param salt salt to be used when hashing the operation batch
+    /// @param delay execution delay in seconds
     function scheduleBatch(
         address[] memory targets,
         uint256[] memory values,
@@ -204,6 +242,11 @@ contract ConfigTimelockController is TimelockController {
         super.scheduleBatch(targets, values, datas, predecessor, salt, delay);
     }
 
+    /// @notice Schedule multiple calls to set protocol address values in the QuantConfig
+    /// @param protocolValues array of protocol address values to be set
+    /// @param newAddresses array of new addresses to be set
+    /// @param quantConfig the address of the QuantConfig contract
+    /// @param eta timestamp from which the scheduled calls can be executed
     function scheduleBatchSetProtocolAddress(
         bytes32[] calldata protocolValues,
         address[] calldata newAddresses,
@@ -230,6 +273,11 @@ contract ConfigTimelockController is TimelockController {
         }
     }
 
+    /// @notice Schedule multiple calls to set protocol uint256 values in the QuantConfig
+    /// @param protocolValues array of protocol uint256 values to be set
+    /// @param newUints array of new uints to be set
+    /// @param quantConfig the address of the QuantConfig contract
+    /// @param eta timestamp from which the scheduled calls can be executed
     function scheduleBatchSetProtocolUints(
         bytes32[] calldata protocolValues,
         uint256[] calldata newUints,
@@ -256,6 +304,11 @@ contract ConfigTimelockController is TimelockController {
         }
     }
 
+    /// @notice Schedule multiple calls to set protocol boolean values in the QuantConfig
+    /// @param protocolValues array of protocol boolean values to be set
+    /// @param newBooleans array of new booleans to be set
+    /// @param quantConfig the address of the QuantConfig contract
+    /// @param eta timestamp from which the scheduled calls can be executed
     function scheduleBatchSetProtocolBooleans(
         bytes32[] calldata protocolValues,
         bool[] calldata newBooleans,
@@ -282,6 +335,11 @@ contract ConfigTimelockController is TimelockController {
         }
     }
 
+    /// @notice Schedule multiple calls to set protocol roles in the QuantConfig
+    /// @param protocolRoles array of protocol roles to be set
+    /// @param roleAdmins array of role admins to be set
+    /// @param quantConfig the address of the QuantConfig contract
+    /// @param eta timestamp from which the scheduled calls can be executed
     function scheduleBatchSetProtocolRoles(
         string[] calldata protocolRoles,
         address[] calldata roleAdmins,
@@ -308,6 +366,11 @@ contract ConfigTimelockController is TimelockController {
         }
     }
 
+    /// @notice Execute a scheduled call to set a protocol address value in the QuantConfig
+    /// @param protocolAddress the protocol address value to be set
+    /// @param newAddress the new address to be set
+    /// @param quantConfig the address of the QuantConfig contract
+    /// @param eta timestamp from which the scheduled call can be executed
     function executeSetProtocolAddress(
         bytes32 protocolAddress,
         address newAddress,
@@ -323,6 +386,11 @@ contract ConfigTimelockController is TimelockController {
         );
     }
 
+    /// @notice Execute a scheduled call to set a protocol uint256 value in the QuantConfig
+    /// @param protocolUint256 the protocol uint256 value to be set
+    /// @param newUint256 the new uint to be set
+    /// @param quantConfig the address of the QuantConfig contract
+    /// @param eta timestamp from which the scheduled call can be executed
     function executeSetProtocolUint256(
         bytes32 protocolUint256,
         uint256 newUint256,
@@ -338,6 +406,11 @@ contract ConfigTimelockController is TimelockController {
         );
     }
 
+    /// @notice Execute a scheduled call to set a protocol boolean value in the QuantConfig
+    /// @param protocolBoolean the protocol boolean value to be set
+    /// @param newBoolean the new boolean to be set
+    /// @param quantConfig the address of the QuantConfig contract
+    /// @param eta timestamp from which the scheduled call can be executed
     function executeSetProtocolBoolean(
         bytes32 protocolBoolean,
         bool newBoolean,
@@ -353,6 +426,11 @@ contract ConfigTimelockController is TimelockController {
         );
     }
 
+    /// @notice Execute a scheduled call to set a protocol role in the QuantConfig
+    /// @param protocolRole the protocol role to be set
+    /// @param roleAdmin the role admin to be set
+    /// @param quantConfig the address of the QuantConfig contract
+    /// @param eta timestamp from which the scheduled call can be executed
     function executeSetProtocolRole(
         string calldata protocolRole,
         address roleAdmin,
@@ -368,6 +446,11 @@ contract ConfigTimelockController is TimelockController {
         );
     }
 
+    /// @notice Execute multiple scheduled calls to set protocol address values in the QuantConfig
+    /// @param protocolValues array of protocol address values to be set
+    /// @param newAddresses array of new addresses to be set
+    /// @param quantConfig the address of the QuantConfig contract
+    /// @param eta timestamp from which the scheduled calls can be executed
     function executeBatchSetProtocolAddress(
         bytes32[] calldata protocolValues,
         address[] calldata newAddresses,
@@ -399,6 +482,11 @@ contract ConfigTimelockController is TimelockController {
         }
     }
 
+    /// @notice Execute multiple scheduled calls to set protocol uint256 values in the QuantConfig
+    /// @param protocolValues array of protocol uint256 values to be set
+    /// @param newUints array of new uints to be set
+    /// @param quantConfig the address of the QuantConfig contract
+    /// @param eta timestamp from which the scheduled calls can be executed
     function executeBatchSetProtocolUint256(
         bytes32[] calldata protocolValues,
         uint256[] calldata newUints,
@@ -430,6 +518,11 @@ contract ConfigTimelockController is TimelockController {
         }
     }
 
+    /// @notice Execute multiple scheduled calls to set protocol boolean values in the QuantConfig
+    /// @param protocolValues array of protocol boolean values to be set
+    /// @param newBooleans array of new booleans to be set
+    /// @param quantConfig the address of the QuantConfig contract
+    /// @param eta timestamp from which the scheduled calls can be executed
     function executeBatchSetProtocolBoolean(
         bytes32[] calldata protocolValues,
         bool[] calldata newBooleans,
@@ -461,6 +554,11 @@ contract ConfigTimelockController is TimelockController {
         }
     }
 
+    /// @notice Execute multiple scheduled calls to set protocol roles in the QuantConfig
+    /// @param protocolRoles array of protocol roles to be set
+    /// @param roleAdmins array of role admins to be set
+    /// @param quantConfig the address of the QuantConfig contract
+    /// @param eta timestamp from which the scheduled calls can be executed
     function executeBatchSetProtocolRoles(
         string[] calldata protocolRoles,
         address[] calldata roleAdmins,
@@ -492,6 +590,10 @@ contract ConfigTimelockController is TimelockController {
         }
     }
 
+    /// @notice Gets the delay to set a specific protocol value using the timelock
+    /// @param quantConfig  the address of the QuantConfig contract
+    /// @param protocolValue the protocol value to get the delay for
+    /// @return the delay required to set the protocol value
     function _getProtocolValueDelay(
         address quantConfig,
         bytes32 protocolValue,
@@ -511,6 +613,13 @@ contract ConfigTimelockController is TimelockController {
         return storedDelay != 0 ? storedDelay : minDelay;
     }
 
+    /// @notice Checks if a given calldata is for setting a protocol value, which could be used
+    /// to bypass the minimum delay required to set a protocol value of a specific type
+    /// @param data the calldata to check
+    /// @return true if the calldata is for setting a protocol value, false otherwise
+    /// @dev There could be a clash between the 4-byte selector for `setProtocolValue` functions
+    /// and other external functions. That's unlikely to happen, but if it does, scheduling calls
+    /// to those functions will always revert.
     function _isProtocoValueSetter(bytes memory data)
         internal
         pure
@@ -528,6 +637,10 @@ contract ConfigTimelockController is TimelockController {
             selector == IQuantConfig(address(0)).setProtocolBoolean.selector;
     }
 
+    /// @notice Encodes the calldata for setting a protocol address value
+    /// @param _protocolAddress the protocol address value to be set
+    /// @param _newAddress the new address to be set
+    /// @param _quantConfig the address of the QuantConfig contract
     function _encodeSetProtocolAddress(
         bytes32 _protocolAddress,
         address _newAddress,
@@ -541,6 +654,10 @@ contract ConfigTimelockController is TimelockController {
             );
     }
 
+    /// @notice Encodes the calldata for setting a protocol uint256 value
+    /// @param _protocolUint256 the protocol uint256 value to be set
+    /// @param _newUint256 the new uint to be set
+    /// @param _quantConfig the address of the QuantConfig contract
     function _encodeSetProtocolUint256(
         bytes32 _protocolUint256,
         uint256 _newUint256,
@@ -554,6 +671,10 @@ contract ConfigTimelockController is TimelockController {
             );
     }
 
+    /// @notice Encodes the calldata for setting a protocol boolean value
+    /// @param _protocolBoolean the protocol boolean value to be set
+    /// @param _newBoolean the new boolean to be set
+    /// @param _quantConfig the address of the QuantConfig contract
     function _encodeSetProtocolBoolean(
         bytes32 _protocolBoolean,
         bool _newBoolean,
@@ -567,6 +688,10 @@ contract ConfigTimelockController is TimelockController {
             );
     }
 
+    /// @notice Encodes the calldata for setting a protocol role
+    /// @param _protocolRole the protocol role to be set
+    /// @param _roleAdmin the role admin to be set
+    /// @param _quantConfig the address of the QuantConfig contract
     function _encodeSetProtocolRole(
         string memory _protocolRole,
         address _roleAdmin,

--- a/contracts/utils/EIP712MetaTransaction.sol
+++ b/contracts/utils/EIP712MetaTransaction.sol
@@ -8,6 +8,8 @@ import "../interfaces/IController.sol";
 import "../libraries/Actions.sol";
 import {ActionArgs} from "../libraries/Actions.sol";
 
+/// @title Contract to be inherited by contracts that want to support meta transactions.
+/// @author Rolla
 contract EIP712MetaTransaction is EIP712Upgradeable {
     using ECDSA for bytes32;
 

--- a/contracts/utils/EIP712MetaTransaction.sol
+++ b/contracts/utils/EIP712MetaTransaction.sol
@@ -33,15 +33,25 @@ contract EIP712MetaTransaction is EIP712Upgradeable {
 
     mapping(address => uint256) private _nonces;
 
+    /// @notice user readable name of signing domain for EIP712 (the protocol name)
     string public name;
+
+    /// @notice the current major version of the signing domain for EIP712
     string public version;
 
+    /// @notice emitted when a meta transaction is executed
     event MetaTransactionExecuted(
         address indexed userAddress,
         address payable indexed relayerAddress,
         uint256 nonce
     );
 
+    /// @notice Given an encoded action and a signature, executes the action on behalf of the signer.
+    /// @param metaAction The encoded action to be executed.
+    /// @param r The r-value of the signature.
+    /// @param s The s-value of the signature.
+    /// @param v The v-value of the signature.
+    /// @return The returned data from the low-level call.
     function executeMetaTransaction(
         MetaAction memory metaAction,
         bytes32 r,
@@ -82,10 +92,17 @@ contract EIP712MetaTransaction is EIP712Upgradeable {
         return returnData;
     }
 
+    /// @notice Returns the current nonce for a user.
+    /// @param user the address of the user to get the nonce for.
+    /// @return nonce the current nonce for the user.
     function getNonce(address user) external view returns (uint256 nonce) {
         nonce = _nonces[user];
     }
 
+    /// @notice initialize method for EIP712Upgradeable
+    /// @dev called once after initial deployment and every upgrade.
+    /// @param _name the user readable name of the signing domain for EIP712
+    /// @param _version the current major version of the signing domain for EIP712
     function initializeEIP712(string memory _name, string memory _version)
         public
         initializer
@@ -96,6 +113,9 @@ contract EIP712MetaTransaction is EIP712Upgradeable {
         __EIP712_init(_name, _version);
     }
 
+    /// @notice Returns the address of the signer when called from this contract,
+    /// otherwise returns the msg.sender
+    /// @return sender the address of the signer or msg.sender
     function _msgSender() internal view returns (address sender) {
         if (msg.sender == address(this)) {
             bytes memory array = msg.data;
@@ -113,6 +133,12 @@ contract EIP712MetaTransaction is EIP712Upgradeable {
         return sender;
     }
 
+    /// @notice Verifies that the signature is valid for a given user and action.
+    /// @param user the address to check as the signer.
+    /// @param metaAction the action struct to check.
+    /// @param r the r-value of the signature.
+    /// @param s the s-value of the signature.
+    /// @param v the v-value of the signature.
     function _verify(
         address user,
         MetaAction memory metaAction,
@@ -133,7 +159,9 @@ contract EIP712MetaTransaction is EIP712Upgradeable {
         return signer == user;
     }
 
-    // functions to generate hash representation of the struct objects
+    /// @notice Hashes a given ActionArgs struct to be used with EIP712.
+    /// @param action the ActionArgs struct to hash.
+    /// @return the hash of the ActionArgs struct.
     function _hashAction(ActionArgs memory action)
         private
         pure
@@ -154,6 +182,9 @@ contract EIP712MetaTransaction is EIP712Upgradeable {
             );
     }
 
+    /// @notice Hashes an array of ActionArgs structs to be used with EIP712.
+    /// @param actions the array of ActionArgs structs to hash.
+    /// @return the array of hashes for the ActionArgs structs.
     function _hashActions(ActionArgs[] memory actions)
         private
         pure
@@ -170,6 +201,9 @@ contract EIP712MetaTransaction is EIP712Upgradeable {
         return hashedActions;
     }
 
+    /// @notice Hashes a MetaAction struct to be used with EIP712.
+    /// @param metaAction the MetaAction struct to hash.
+    /// @return the hash of the MetaAction struct.
     function _hashMetaAction(MetaAction memory metaAction)
         private
         pure

--- a/contracts/utils/OperateProxy.sol
+++ b/contracts/utils/OperateProxy.sol
@@ -3,7 +3,10 @@ pragma solidity 0.8.12;
 
 import "../interfaces/IOperateProxy.sol";
 
+/// @title Contract to be used by the Controller to make unprivileged external calls
+/// @author Rolla
 contract OperateProxy is IOperateProxy {
+    /// @inheritdoc IOperateProxy
     function callFunction(address callee, bytes memory data) external override {
         require(
             callee != address(0),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rolla-contracts/quant-protocol",
-  "version": "0.10.0",
+  "version": "0.10.2",
   "description": "Smart contracts for the Quant Protocol.",
   "scripts": {
     "build": "hardhat compile",

--- a/spec/harness/CollateralTokenHarness.sol
+++ b/spec/harness/CollateralTokenHarness.sol
@@ -8,7 +8,7 @@ contract CollateralTokenHarness is CollateralToken {
     ////////////////////////////////////////////////////////////////////////////
     constructor(address _quantConfig)
         public
-        CollateralToken(_quantConfig, "", "")
+        CollateralToken(_quantConfig, "", "", "")
     {}
 
     ////////////////////////////////////////////////////////////////////////////

--- a/spec/harness/CollateralTokenHarness.sol
+++ b/spec/harness/CollateralTokenHarness.sol
@@ -8,7 +8,12 @@ contract CollateralTokenHarness is CollateralToken {
     ////////////////////////////////////////////////////////////////////////////
     constructor(address _quantConfig)
         public
-        CollateralToken(_quantConfig, "", "", "")
+        CollateralToken(
+            _quantConfig,
+            "",
+            "",
+            "https://tokens.rolla.finance/{id}.json"
+        )
     {}
 
     ////////////////////////////////////////////////////////////////////////////

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -129,11 +129,13 @@ const deployCollateralToken = async (
   deployer: Signer,
   quantConfig: QuantConfig
 ): Promise<CollateralToken> => {
+  const erc1155Uri = "https://tokens.rolla.finance/{id}.json";
   const collateralToken = <CollateralToken>(
     await deployContract(deployer, CollateralTokenJSON, [
       quantConfig.address,
       name,
       version,
+      erc1155Uri,
     ])
   );
 


### PR DESCRIPTION
- refactor: mark contracts as abstract
- docs: add missing NatSpec and docstrings
- Add docs to FundsCalculator
- refactor: parameterize ERC1155 URI in the CollateralToken
- fix: CollateralTokenHarness constructor missing URI argument
- Add more docs to calculators
- fix: clashing URI parameter name
- fix: Certora CollateralTokenHarness empty URI
- docs: add remaining documentation
- docs(quant-config) add @dev docstring
