### PR TITLE
fix: replace ecrecover with Open Zeppelin's ECDSA.recover

### DIFF
--- a/test/CollateralToken.test.ts
+++ b/test/CollateralToken.test.ts
@@ -167,7 +167,7 @@ describe("CollateralToken", () => {
             ethers.constants.HashZero,
             ethers.constants.HashZero
           )
-      ).to.be.revertedWith("CollateralToken: invalid signature");
+      ).to.be.revertedWith("ECDSA: invalid signature 'v' value");
     });
 
     it("Should revert when passing an invalid nonce", async () => {


### PR DESCRIPTION
this adds the additional check for the recovered signer not to be the zero address